### PR TITLE
Port TL cogs to discord.py 2.6 APIs

### DIFF
--- a/cleverbot/cleverbot.py
+++ b/cleverbot/cleverbot.py
@@ -234,7 +234,7 @@ class Cleverbotcog(commands.Cog):
         embed.title = "Options for cleverbot:"
         embed.colour = discord.Colour.dark_red()
         nevus = self.bot.get_user(473446760233041929)
-        embed.set_footer(text="Bot by " + nevus.name, icon_url=nevus.avatar_url)
+        embed.set_footer(text="Bot by " + nevus.name, icon_url=nevus.display_avatar.url)
         # Put in code block to preserve spaces
         embed.description = "```{}```".format(options_str)
         await ctx.send(embed=embed)

--- a/crtoolsdb/crtoolsdb.py
+++ b/crtoolsdb/crtoolsdb.py
@@ -421,7 +421,7 @@ class ClashRoyaleTools(commands.Cog):
             self.tags.saveTag(userID=user.id, tag=tag)
             embed = discord.Embed(color=discord.Color.green(),
                                   description="Use !accounts to see all accounts")
-            avatar = user.avatar_url if user.avatar else user.default_avatar_url
+            avatar = user.display_avatar.url
             embed.set_author(name='{} (#{}) has been successfully saved.'.format(name, tag),
                              icon_url=avatar)
             embed.set_footer(text="Bot by: Generaleoley | Legend Gaming")

--- a/extendedmodlog/eventmixin.py
+++ b/extendedmodlog/eventmixin.py
@@ -251,7 +251,7 @@ class EventMixin:
             author_title = _("{member} ({m_id})- Used a Command").format(
                 member=message.author, m_id=message.author.id
             )
-            embed.set_author(name=author_title, icon_url=message.author.avatar_url)
+            embed.set_author(name=author_title, icon_url=message.author.display_avatar.url)
             await channel.send(embed=embed)
         else:
             await channel.send(infomessage[:2000])
@@ -379,7 +379,7 @@ class EventMixin:
             embed.set_footer(text=_("User ID: ") + str(message.author.id))
             embed.set_author(
                 name=_("{member} ({m_id})- Deleted Message").format(member=author, m_id=author.id),
-                icon_url=str(message.author.avatar_url),
+                icon_url=message.author.display_avatar.url,
             )
             await channel.send(embed=embed)
         else:
@@ -582,12 +582,12 @@ class EventMixin:
                 name=_("{member} ({m_id}) has joined the server").format(
                     member=member, m_id=member.id
                 ),
-                url=member.avatar_url,
-                icon_url=member.avatar_url,
+                url=member.display_avatar.url,
+                icon_url=member.display_avatar.url,
             )
             if possible_link:
                 embed.add_field(name=_("Invite Link"), value=possible_link)
-            embed.set_thumbnail(url=member.avatar_url)
+            embed.set_thumbnail(url=member.display_avatar.url)
             await channel.send(embed=embed)
         else:
             time = datetime.datetime.utcnow()
@@ -648,10 +648,10 @@ class EventMixin:
                 name=_("{member} ({m_id}) has left the server").format(
                     member=member, m_id=member.id
                 ),
-                url=member.avatar_url,
-                icon_url=member.avatar_url,
+                url=member.display_avatar.url,
+                icon_url=member.display_avatar.url,
             )
-            embed.set_thumbnail(url=member.avatar_url)
+            embed.set_thumbnail(url=member.display_avatar.url)
             await channel.send(embed=embed)
         else:
             time = datetime.datetime.utcnow()
@@ -1229,7 +1229,7 @@ class EventMixin:
                 name=_("{member} ({m_id}) - Edited Message").format(
                     member=before.author, m_id=before.author.id
                 ),
-                icon_url=str(before.author.avatar_url),
+                icon_url=before.author.display_avatar.url,
             )
             await channel.send(embed=embed)
         else:
@@ -1601,7 +1601,7 @@ class EventMixin:
             m_id=before.id,
         )
         emb_msg = _("{member} ({m_id}) updated").format(member=before, m_id=before.id)
-        embed.set_author(name=emb_msg, icon_url=before.avatar_url)
+        embed.set_author(name=emb_msg, icon_url=before.display_avatar.url)
         member_updates = {"nick": _("Nickname:"), "roles": _("Roles:")}
         perp = None
         reason = None

--- a/modP/names.py
+++ b/modP/names.py
@@ -285,7 +285,7 @@ class ModInfo(MixinMeta):
         name = " ~ ".join((name, user.nick)) if user.nick else name
         name = filter_invites(name)
 
-        avatar = user.avatar_url_as(static_format="png")
+        avatar = user.display_avatar.url
         data.set_author(name=f"{statusemoji} {name}", url=avatar)
         data.set_thumbnail(url=avatar)
 

--- a/trade/trade.py
+++ b/trade/trade.py
@@ -207,7 +207,8 @@ class Trade(commands.Cog):
         return { **token_trades, **sorted2}
         
 
-    @commands.group(pass_context = True, no_pm=True)
+    @commands.group()
+    @commands.guild_only()
     async def trade(self, ctx):
         """ Clash Royale trade commands"""
         pass
@@ -221,7 +222,7 @@ class Trade(commands.Cog):
     async def want_add(self, ctx, *, card):
         """Add card that you are looking for"""
         
-        author = ctx.message.author
+        author = ctx.author
         
         try:
             card = self.cards_abbrev[card]
@@ -238,7 +239,7 @@ class Trade(commands.Cog):
     async def want_remove(self, ctx, *, card):
         """Remove card that you are no longer looking for"""
         
-        author = ctx.message.author
+        author = ctx.author
         try:
             card = self.cards_abbrev[card]
         except KeyError:
@@ -256,7 +257,7 @@ class Trade(commands.Cog):
     async def give_add(self, ctx, *, card):    
         """Add card that you want to give away"""        
         
-        author = ctx.message.author
+        author = ctx.author
         
         try:
             card = self.cards_abbrev[card]
@@ -273,7 +274,7 @@ class Trade(commands.Cog):
     async def give_remove(self, ctx, *, card):
         """Remove card that you no longer want to give away"""
         
-        author = ctx.message.author
+        author = ctx.author
         try:
             card = self.cards_abbrev[card]
         except KeyError:
@@ -283,11 +284,12 @@ class Trade(commands.Cog):
         await ctx.send("You are no longer looking to give away {}".format(card))
 
         
-    @trade.command(pass_context=True, no_pm=True)
+    @trade.command()
+    @commands.guild_only()
     async def search(self, ctx, *, card):
         """Search for trades"""
-        
-        author = ctx.message.author
+
+        author = ctx.author
         server = ctx.guild
         
         try:
@@ -354,7 +356,7 @@ class Trade(commands.Cog):
         
         if token in token_type:
             
-            author = ctx.message.author
+            author = ctx.author
             token = token.lower()
         
             try:
@@ -371,7 +373,7 @@ class Trade(commands.Cog):
         """Remove trade token"""
         
         if token in token_type:
-            author = ctx.message.author
+            author = ctx.author
             token = token.lower()
         
             try:
@@ -388,7 +390,7 @@ class Trade(commands.Cog):
         """Display trade data of user"""
         
         member_data = await self.database.member(ctx.author).all()
-        pfp = ctx.author.avatar_url
+        pfp = ctx.author.display_avatar.url
         
         embed = discord.Embed(color=0xFAA61A, description="Trade user info.")
         embed.set_author(name="{} ".format(ctx.author.display_name),

--- a/welcomer/welcomer.py
+++ b/welcomer/welcomer.py
@@ -339,7 +339,7 @@ class Welcomer(commands.Cog):
         channel = self.bot.get_channel(await self.config.log_channel_id())
 
         embed = discord.Embed(color=discord.Color.green(), description="User Joined")
-        avatar = user.avatar_url if user.avatar else user.default_avatar_url
+        avatar = user.display_avatar.url
         embed.set_author(name=user.name, icon_url=avatar)
 
         try:
@@ -420,7 +420,7 @@ class Welcomer(commands.Cog):
             return
 
         embed = discord.Embed(color=discord.Color.red(), description="User Left")
-        avatar = member.avatar_url if member.avatar else member.default_avatar_url
+        avatar = member.display_avatar.url
         embed.set_author(name=member.display_name, icon_url=avatar)
         channel = self.bot.get_channel(await self.config.log_channel_id())
         await channel.send(embed=embed)


### PR DESCRIPTION
## Summary
- replace deprecated avatar_url accessors with display_avatar to match discord.py 2.6
- remove deprecated pass_context/no_pm usage from the trade command group and gate it to guilds
- keep cog embeds and metadata aligned with the Discord 2.6 asset API for Red 3.5+

## Testing
- python -m compileall trade/trade.py modP/names.py welcomer/welcomer.py cleverbot/cleverbot.py extendedmodlog/eventmixin.py crtoolsdb/crtoolsdb.py

------
https://chatgpt.com/codex/tasks/task_e_68cca9bdabf0832f9bc3595a760db029